### PR TITLE
Ошибка исправлена. NullPointerException бросался в сериализаторе. У т…

### DIFF
--- a/src/main/java/com/github/zigcat/Main.java
+++ b/src/main/java/com/github/zigcat/Main.java
@@ -63,8 +63,12 @@ public class Main {
         smUm.addDeserializer(UserMusic.class, new UserMusicDeserializer());
         omUm.registerModule(smUm);
 //starting app
-        Javalin app = Javalin.create();
-        app.config = new JavalinConfig().enableDevLogging();
+        Javalin app = Javalin.create(javalinConfig -> {
+            javalinConfig.enableCorsForAllOrigins();
+            javalinConfig.enableDevLogging();
+            javalinConfig.defaultContentType = "application/json";
+            javalinConfig.prefer405over404 = true;
+        });
         app.start(34567);
 //implementing app's methods
 //user CRUD

--- a/src/main/java/com/github/zigcat/jackson/deserializers/MusicDeserializer.java
+++ b/src/main/java/com/github/zigcat/jackson/deserializers/MusicDeserializer.java
@@ -14,12 +14,15 @@ import com.github.zigcat.ormlite.exception.CustomException;
 import com.github.zigcat.ormlite.exception.NotFoundException;
 import com.github.zigcat.ormlite.models.*;
 import com.github.zigcat.services.Security;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.LocalDate;
 
 public class MusicDeserializer extends StdDeserializer<Music> {
+    static Logger logger = LoggerFactory.getLogger(MusicDeserializer.class);
     protected MusicDeserializer(Class<?> vc) {
         super(vc);
     }
@@ -38,32 +41,47 @@ public class MusicDeserializer extends StdDeserializer<Music> {
 
     @Override
     public Music deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        logger.info("Deserializing music object");
         JsonNode node = jsonParser.getCodec().readTree(jsonParser);
         int id = node.get("id").asInt();
+        logger.info("id = " + id);
         String name = node.get("name").asText();
+        logger.info("name = " + name);
         int genre = node.get("genre").asInt();
+        logger.info("genre = " + genre);
         int author = node.get("author").asInt();
+        logger.info("author = " + author);
         int group = node.get("group").asInt();
+        logger.info("group = " + group);
         String creation = node.get("creationDate").asText();
+        logger.info("creationDate = " + creation );
         String content = node.get("content").asText();
+        logger.info("content = " + content);
         int album = node.get("album").asInt();
+        logger.info("album = "+ album);
         Album album1;
         Genre genre1;
         Author author1;
         Group group1;
         if(!Security.isValidDate(creation)){
+            logger.warn("Security Check Failed");
             throw new CustomException("Creation date is empty/not valid(400)");
         } else {
             try {
                 album1 = AlbumController.albumService.getById(album);
+                logger.info("Retrieved album1 from service = " + album1);
                 genre1 = GenreController.genreService.getById(genre);
+                logger.info("Retrieved genre1 from service = " + genre1);
+
                 if(genre1 == null){
                     throw new NotFoundException("Genre is not valid(404)");
                 }
                 if(group == 0 && author == 0){
                     throw new CustomException("Creator is not valid, because song has 2 creators(400)");
                 } else if(author != 0){
+                    logger.info("author != 0");
                     author1 = AuthorController.authorService.getById(author);
+                    logger.info("Retrieved author1 from service = " + author1);
                     if(author1 != null){
                         return new Music(id, name, genre1 ,author1, album1, null,
                                 LocalDate.parse(creation, User.dateTimeFormatter), content);

--- a/src/main/java/com/github/zigcat/jackson/serializers/MusicSerializer.java
+++ b/src/main/java/com/github/zigcat/jackson/serializers/MusicSerializer.java
@@ -36,19 +36,17 @@ public class MusicSerializer extends StdSerializer<Music> {
 
     @Override
     public void serialize(Music music, JsonGenerator json, SerializerProvider serializerProvider) throws IOException {
-        try {
-            json.writeStartObject();
-            json.writeNumberField("id", music.getId());
-            json.writeStringField("name", music.getName());
-            json.writeStringField("creationDate", music.getCreationDate());
-            json.writeObjectField("genre", GenreController.genreService.getById(music.getGenre().getId()));
-            json.writeObjectField("author", AuthorController.authorService.getById(music.getAuthor().getId()));
-            json.writeObjectField("group", GroupController.groupService.getById(music.getGroup().getId()));
-            json.writeObjectField("album", AlbumController.albumService.getById(music.getAlbum().getId()));
-            json.writeStringField("content", music.getContent());
-            json.writeEndObject();
-        } catch (SQLException e) {
-            e.printStackTrace();
-        }
+
+        json.writeStartObject();
+        json.writeNumberField("id", music.getId());
+        json.writeStringField("name", music.getName());
+        json.writeStringField("creationDate", music.getCreationDate());
+        json.writeObjectField("genre", music.getGenre());
+        json.writeObjectField("author", music.getAuthor());
+        json.writeObjectField("group", music.getGroup());
+        json.writeObjectField("album", music.getAlbum());
+        json.writeStringField("content", music.getContent());
+        json.writeEndObject();
+
     }
 }

--- a/src/main/java/com/github/zigcat/services/AlbumService.java
+++ b/src/main/java/com/github/zigcat/services/AlbumService.java
@@ -20,7 +20,7 @@ public class AlbumService {
     }
 
     public Album getById(int id) throws SQLException {
-        l.info("@@@\tgetting author by id");
+        l.info("@@@\tgetting author by id"); //??? Getting Author? TODO(Solomon) fix the typo
         for(Album a: AlbumController.albumDao.queryForAll()){
             l.info("Iterating over "+a.toString());
             if(a.getId() == id){


### PR DESCRIPTION
…ебя ведь по задумке null должен быть или автор, или группа, так ты определяешь, являлся ли трек сольным. Из-за этого, getAuthor() или getGroup() давали null (гарантированно один из них). Следовательно, getAuthor().getId() бросает ошибку, если была указана группа и getGroup().getId() бросает ошибку, если был указан автор, поэтому они у тебя то работали, то нет. Ты не проверил записи в базе, в базе видно, что одно из полей действительно всегда null. Из-за того, что ты включил foreignAutoRefresh, теперь ты можешь просто отдавать объект. Если бы ты этого не сделал (не включал foreignAutoRefresh), то тебе пришлось бы просто добавить один if с проверкой на нулловость, прежде, чем дергать сервис.